### PR TITLE
NetworkManagerController component requires SyncNetworkManager

### DIFF
--- a/Assets/Packages/SyncUtil/Scripts/NetworkManagerController.cs
+++ b/Assets/Packages/SyncUtil/Scripts/NetworkManagerController.cs
@@ -8,6 +8,7 @@ using UnityEngine.Networking;
 
 namespace SyncUtil
 {
+	[RequireComponent(typeof(SyncNetworkManager))]
     public class NetworkManagerController : MonoBehaviour
     {
         #region TypeDefine
@@ -33,6 +34,7 @@ namespace SyncUtil
         public virtual void Start()
         {
             _networkManager = GetComponent<SyncNetworkManager>();
+			Assert.IsTrue(_networkManager);
 
             if (_bootType != BootType.Manual) StartNetwork(_bootType);
         }


### PR DESCRIPTION
NetworkManagerController  depends on SyncNetworkManager being in the same game object.
I made the dependency clearer by adding [RequireComponent] and an assert